### PR TITLE
add timeout and resuming downloads

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -46,6 +46,7 @@ def download(passed_from_main):
     try:
         while True:
             filename = _item[_item.rfind("/") + 1:]
+            filenameTemp = f'{filename}.download'
             _url = _item
 
             if attemptsToTry != 0 and attempts >= attemptsToTry:
@@ -58,10 +59,21 @@ def download(passed_from_main):
                     if filename == "cyberdrop.me-downloaders":
                         break
 
-                    response = requests.get(_url, stream=True)
-                    incomingFileSize = int(response.headers['Content-length'])
+                    headers = {}
+                    resume = False
 
-                    if os.path.isfile(_path + str(filename)):
+                    if os.path.isfile(_path + str(filenameTemp)):
+                        storedFileSize = os.path.getsize(_path + str(filenameTemp))
+                        log("           " + filename + f" already exists (partial, {storedFileSize} B).", Fore.LIGHTBLACK_EX)
+                        headers['Range'] = f'bytes={storedFileSize}-'
+                        resume = True
+
+                    head_response = requests.head(_url)
+                    incomingFileSize = int(head_response.headers['Content-length'])
+                    del head_response
+                    response = requests.get(_url, stream=True, timeout=30, headers=headers)
+
+                    if not resume and os.path.isfile(_path + str(filename)):
                         storedFileSize = os.path.getsize(_path + str(filename))
                         if incomingFileSize == storedFileSize:
                             log("           " + filename + " already exists.", Fore.LIGHTBLACK_EX)
@@ -72,14 +84,15 @@ def download(passed_from_main):
 
                     log("        Downloading " + filename + "...", Fore.LIGHTBLACK_EX)
 
-                    with open(_path + str(filename), "wb") as out_file:
+                    with open(_path + str(filenameTemp), "ab" if resume else "wb") as out_file:
                         for chunk in response.iter_content(chunk_size=50000):
                             if chunk:
                                 out_file.write(chunk)
                     del response
-                    if os.path.isfile(_path + str(filename)):
-                        storedFileSize = os.path.getsize(_path + str(filename))
+                    if os.path.isfile(_path + str(filenameTemp)):
+                        storedFileSize = os.path.getsize(_path + str(filenameTemp))
                         if incomingFileSize == storedFileSize:
+                            os.rename(_path + str(filenameTemp), _path + str(filename))
                             log("        Finished " + filename, Fore.GREEN)
                             break
                         else:
@@ -90,7 +103,6 @@ def download(passed_from_main):
                         attempts += 1
                 except Exception as e:
                     # log(e, Fore.RED)
-                    os.remove(_path + str(filename))
                     log("        Failed attempt " + str(attempts) + " for " + filename, Fore.RED)
                     attempts += 1
 


### PR DESCRIPTION
Adds a 30 second timeout to the download request. This should probably be configured through the settings file, and also should probably be a separate pull request? Having the timeout resolved an issue I had with larger image files (2MB+) where they would sometimes be stuck in "downloading" forever without any network activity.

----

The other important change is resuming downloads.  
While downloading the contents are written to `filename.extension.download` (e.g. `some_image.jpg.download`). If the download attempt fails, the local file is not removed. On the next attempt the `*.download` file is found, size checked, download request made with `Range` header to retrieve only the rest of the file, and the local file is opened as append (`ab`) instead of write (`wb`).  
Once the download is complete `filename.extension.download` is renamed to `filename.extension`.

Since the `Content-length` header is usually not available on requests with the `Range` header, the `incomingFileSize` is retrieved with a separate `HEAD` (instead of `GET`) request, that only retrieves the response headers.