### PR TITLE
Added information about the package on the AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ https://www.python.org/ftp/python/3.9.6/python-3.9.6-amd64.exe
 
 Use this installer to install python, make sure you select the box that says "ADD TO PATH"
 
+**Arch Linux**
+
+There is a package on the AUR named [`cyberdropdownloader-bin`](https://aur.archlinux.org/packages/cyberdropdownloader-bin/).
+
+This can be installed using your preffered AUR helper with a command like `paru -Sy cyberdropdownloader-bin`. You can then run the program by running `$ cyberdrop-downloader`. This will create a `URLS.txt` file in your current path which you can populate to proceed with your downloads.
+
 # Usage
 Copy and paste links into URLs.txt. 
 Each link you add has to go on it's own line. (paste link, press enter, repeat).


### PR DESCRIPTION
I created a new package on the AUR which I intend to maintain unless the maintainers of this project want ownership. Through this commit I am adding information about the package, making your project easily available to the users of ArchLinux and it's sub-distros like Manjaro.


**Also, I am participating in Hacktoberfest this year even though I am doing regular PRs on various repositories. So if you don't mind, could you please help me by adding a label `hacktoberfest-accepted`**

Here's the rule listed in their FAQ:

>Your pull requests will count toward your participation if they are in a repository with the 'hacktoberfest 'topic and once they have been merged, approved by a maintainer or labeled as **hacktoberfest-accepted**. 

>Additionally, any pull request with the **hacktoberfest-accepted** label, submitted to any public GitHub/GitLab repository, with or without the hacktoberfest topic, will be considered valid for Hacktoberfest.