### PR TITLE
Remove asyncio from dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-asyncio~=3.4.3
 requests~=2.26.0
 colorama~=0.4.4
 Scrapy~=2.5.1


### PR DESCRIPTION
`asyncio` is built-in module since Python 3.4.