### PR TITLE
Fix missing , in supported_hosts

### DIFF
--- a/cyberdrop_dl/base_functions/data_classes.py
+++ b/cyberdrop_dl/base_functions/data_classes.py
@@ -138,7 +138,7 @@ class AuthData:
 @dataclass
 class SkipData:
     supported_hosts: ClassVar[Tuple[str]] = (
-        "anonfiles", "bayfiles", "bunkr", "coomer.party", "cyberdrop", "cyberfile", "erome", "gfycat", "gofile", "img.kiwi"
+        "anonfiles", "bayfiles", "bunkr", "coomer.party", "cyberdrop", "cyberfile", "erome", "gfycat", "gofile", "img.kiwi",
         "jpg.church", "jpg.homes", "kemono.party", "leakednudes", "pixeldrain", "pixl.is", "postimg.cc", "putme.ga",
         "putmega.com", "redgifs", "saint", "socialmediagirls", "simpcity")
     sites: List[str]


### PR DESCRIPTION
jpg.church wasn't skippable because of a missing "," in supported_hosts