### PR TITLE
Add basic proxy support

### DIFF
--- a/cyberdrop_dl/client/client.py
+++ b/cyberdrop_dl/client/client.py
@@ -119,13 +119,13 @@ class DownloadSession:
 
     async def download_file(self, url: URL, referer: str, current_throttle: int, range: str, original_filename: str,
                             filename: str, temp_file: str, resume_point: int, show_progress: bool,
-                            File_Lock: FileLock, folder: Path, title: str):
+                            File_Lock: FileLock, folder: Path, title: str, proxy: str):
         headers = {'Referer': referer, 'user-agent': self.client.user_agent}
         if range:
             headers['Range'] = range
         await throttle(self, current_throttle, url.host)
         async with self.client_session.get(url, headers=headers, ssl=self.client.ssl_context,
-                                           raise_for_status=True) as resp:
+                                           raise_for_status=True, proxy=proxy) as resp:
             content_type = resp.headers.get('Content-Type')
             if 'text' in content_type.lower() or 'html' in content_type.lower():
                 logger.debug("Server for %s is either down or the file no longer exists", str(url))

--- a/cyberdrop_dl/main.py
+++ b/cyberdrop_dl/main.py
@@ -38,6 +38,7 @@ def parse_args():
     parser.add_argument("--exclude-other", help="skip downloading of images", action="store_true")
     parser.add_argument("--ignore-history", help="This ignores previous download history", action="store_true")
     parser.add_argument("--output-last-forum-post", help="Separates forum scraping into folders by post number", action="store_true")
+    parser.add_argument("--proxy", help="HTTP/HTTPS proxy used for downloading, format [protocal]://[ip]:[port]", default=None)
     parser.add_argument("--separate-posts", help="Separates forum scraping into folders by post number", action="store_true")
     parser.add_argument("--xbunker-username", type=str, help="username to login to xbunker", default=None)
     parser.add_argument("--xbunker-password", type=str, help="password to login to xbunker", default=None)
@@ -111,7 +112,7 @@ async def download_all(args: argparse.Namespace):
 
     downloaders = await get_downloaders(content_object, folder=args.output_folder, attempts=args.attempts,
                                         disable_attempt_limit=args.disable_attempt_limit, max_workers=threads,
-                                        excludes=excludes, SQL_helper=SQL_helper, client=client)
+                                        excludes=excludes, SQL_helper=SQL_helper, client=client, proxy=args.proxy)
 
     for downloader in downloaders:
         await downloader.download_content(conn_timeout=args.connection_timeout)


### PR DESCRIPTION
Add a CLI option `--proxy`, when specified, the downloader will pass the proxy to `aiohttp.ClientSession().get()` method, enabling possible faster download in network limited areas. If omit this option, it will pass a default `None` and files would be downloaded directly.

I have done test with local HTTP proxy on a GoFile link, everything works as normal.

Note: No additional error handling for proxy usage is implemented.