### PR TITLE
Add Rule34.xxx support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The latest version of the program is 3.3.35
 | Pixl             | Albums: pixl.is/album/... <br> Direct Images: pixl.is/image/...  <br> User Profile: pixl.is/#USER# <br> All User Albums: pixl.is/#USER#/albums                                                                                         |
 | Postimg.cc       | Albums: postimg.cc/gallery/... <br> Direct Images: postimg.cc/...                                                                                                                                                                      |
 | SocialMediaGirls | Thread: forum.socialmediagirls.com/threads/...  <br> Continue from (will download this post and after): forum.socialmediagirls.com/threads/...post-NUMBER                                                                              |
+| rule34.xxx | Direct Media (Image and Video): rule34.xxx/index.php?page=post&s=view&id=... |
 | SimpCity         | Thread: simpcity.st/threads/...  <br> Continue from (will download this post and after): simpcity.st/threads/...post-NUMBER                                                                                                            | 
 | XBunkr           | Album: xbunkr.com/a/... <br> Direct Links: media.xbunkr.com/...                                                                                                                                                                        |
 

--- a/cyberdrop_dl/base_functions/data_classes.py
+++ b/cyberdrop_dl/base_functions/data_classes.py
@@ -140,5 +140,5 @@ class SkipData:
     supported_hosts: ClassVar[Tuple[str]] = (
         "anonfiles", "bayfiles", "bunkr", "coomer.party", "cyberdrop", "cyberfile", "erome", "gfycat", "gofile", "img.kiwi",
         "jpg.church", "jpg.homes", "kemono.party", "pixeldrain", "pixl.is", "postimg.cc", "putme.ga",
-        "putmega.com", "redgifs", "saint", "socialmediagirls", "simpcity", "xbunker", "xbunkr")
+        "putmega.com", "redgifs", "rule34", "saint", "socialmediagirls", "simpcity", "xbunker", "xbunkr")
     sites: List[str]

--- a/cyberdrop_dl/client/client.py
+++ b/cyberdrop_dl/client/client.py
@@ -3,6 +3,7 @@ import json
 import logging
 import ssl
 from pathlib import Path
+import xml.etree.ElementTree as ET
 
 import aiofiles
 from bs4 import BeautifulSoup
@@ -57,6 +58,14 @@ class Session:
                 async with self.client_session.get(url, ssl=self.client.ssl_context) as response:
                     content = json.loads(await response.content.read())
                     return content
+
+    async def get_xml(self, url: URL):
+        async with self.client.simultaneous_session_limit:
+            async with self.rate_limiter:
+                async with self.client_session.get(url, ssl=self.client.ssl_context) as response:
+                    text = await response.content.read()
+                    xmlTree = ET.fromstring(text)
+                    return xmlTree
 
     async def post_no_resp(self, url: URL, headers: dict):
         async with self.client.simultaneous_session_limit:

--- a/cyberdrop_dl/crawlers/Rule34_Spider.py
+++ b/cyberdrop_dl/crawlers/Rule34_Spider.py
@@ -1,0 +1,36 @@
+from xml.etree.ElementTree import Element
+from yarl import URL
+
+from ..base_functions.base_functions import log, logger
+from ..base_functions.data_classes import DomainItem
+from ..client.client import Session
+
+
+class Rule34Crawler:
+    async def fetch(self, session: Session, url: URL):
+        try:
+            # get the &id=1234 part from the url
+            # an url can look like this:
+            # https://rule34.xxx/index.php?page=post&s=view&id=6766683
+            id = url.query['id']
+
+            # call the api for
+            # https://api.rule34.xxx/index.php?page=dapi&s=post&q=index&id=${OUR_ID}
+            apiUrl = URL("https://api.rule34.xxx/index.php?page=dapi&s=post&q=index&id=" + id)
+            response = await session.get_xml(apiUrl)
+
+            for child in response:
+                if child.tag != "post":
+                    continue
+                file_url = child.attrib["file_url"]
+                break
+
+            domain_object = DomainItem("rule34.xxx", {})
+            await domain_object.add_to_album("Rule34", URL(file_url), url)
+            
+            return domain_object
+
+        except Exception as e:
+            logger.debug("Error encountered while handling %s", str(url), exc_info=True)
+            await log("Error scraping " + str(url))
+            logger.debug(e)

--- a/cyberdrop_dl/scraper/scraper_helper.py
+++ b/cyberdrop_dl/scraper/scraper_helper.py
@@ -4,6 +4,7 @@ import aiofiles
 from myjdapi import myjdapi
 from yarl import URL
 
+
 from ..client.client import Client
 from ..client.client import Session
 from ..crawlers.Anonfiles_Spider import AnonfilesCrawler
@@ -18,6 +19,7 @@ from ..crawlers.Kemono_Spider import KemonoCrawler
 from ..crawlers.Pixeldrain_Spider import PixelDrainCrawler
 from ..crawlers.Postimg_Spider import PostImgCrawler
 from ..crawlers.Redgifs_Spider import RedGifsCrawler
+from ..crawlers.Rule34_Spider import Rule34Crawler
 from ..crawlers.Saint_Spider import SaintCrawler
 from ..crawlers.ShareX_Spider import ShareXCrawler
 from ..crawlers.SocialMediaGirls_Spider import SocialMediaGirlsCrawler
@@ -59,6 +61,7 @@ class ScrapeMapper():
         self.pixeldrain_crawler = None
         self.postimg_crawler = None
         self.redgifs_crawler = None
+        self.rule34_crawler = None
         self.saint_crawler = None
         self.sharex_crawler = None
         self.socialmediagirls_crawler = None
@@ -79,7 +82,7 @@ class ScrapeMapper():
                         "img.kiwi": self.ShareX, "jpg.church": self.ShareX, "jpg.homes": self.ShareX,
                         "kemono.party": self.Kemono, "pixeldrain.com": self.Pixeldrain, "pixl.is": self.ShareX,
                         "postimg": self.Postimg, "putme.ga": self.ShareX, "putmega.com": self.ShareX,
-                        "redgifs.com": self.redgifs, "saint.to": self.Saint, "socialmediagirls": self.SocialMediaGirls,
+                        "redgifs.com": self.redgifs, "rule34.xxx": self.Rule34, "saint.to": self.Saint, "socialmediagirls": self.SocialMediaGirls,
                         "simpcity": self.SimpCity, "xbunker": self.XBunker}
 
     async def Anonfiles(self, url: URL, title=None):
@@ -211,6 +214,19 @@ class ScrapeMapper():
             else:
                 await self.Cascade.add_to_album("redgifs.com", "gifs", content_url, url)
         await redgifs_session.exit_handler()
+
+    async def Rule34(self, url: URL, title=None):
+        rule34_session = Session(self.client)
+        if not self.rule34_crawler:
+            self.rule34_crawler = Rule34Crawler()
+        domain_obj = await self.rule34_crawler.fetch(rule34_session, url)
+        
+        if title:
+            await domain_obj.append_title(title)
+        await self.Cascade.add_albums(domain_obj)
+            
+        await rule34_session.exit_handler()
+
 
     async def Saint(self, url: URL, title=None):
         saint_session = Session(self.client)


### PR DESCRIPTION
Hello,

rule34.xxx hosts lots of images and videos of the 2D variety.

As this is a great mass downloader for all sorts of content, i think this would fit in nicely.

R34.xxx provides an authentication-free API with a non-defined ratelimit, which is used instead of regular scraping. It also returns XML, therefore there is an additional get_xml utility function in this PR.

Hope this is wanted :) 