### PR TITLE
Make folder names consistant 

### DIFF
--- a/cyberdrop_dl/crawlers/Anonfiles_Spider.py
+++ b/cyberdrop_dl/crawlers/Anonfiles_Spider.py
@@ -17,7 +17,7 @@ class AnonfilesCrawler:
         if 'cdn' in url.host:
             url = URL("https://anonfiles.com") / url.parts[1]
 
-        album_obj = AlbumItem("Anon Loose Files", [])
+        album_obj = AlbumItem("Loose Anon Files", [])
 
         await log(f"[green]Starting: {str(url)}[/green]", quiet=self.quiet)
 

--- a/cyberdrop_dl/crawlers/Bunkr_Spider.py
+++ b/cyberdrop_dl/crawlers/Bunkr_Spider.py
@@ -18,7 +18,7 @@ class BunkrCrawler:
 
     async def fetch(self, session: ScrapeSession, url: URL):
         """Scraper for Bunkr"""
-        album_obj = AlbumItem("Loose Bunkr Items", [])
+        album_obj = AlbumItem("Loose Bunkr Files", [])
         await log(f"[green]Starting: {str(url)}[/green]", quiet=self.quiet)
 
         if "v" in url.parts or "d" in url.parts:


### PR DESCRIPTION
When checking the default folder names there appear to be a few that do not follow the naming convention. This PR is to correct those.
```bash
# grep -Roh "\".*Loose.*\""
"Anon Loose Files" <-
"Loose Bunkr Items" <-
"Loose Coomer Files"
"Loose Kemono Files"
"Loose CyberFile Files"
"Loose Cyberdrop Files"
"Loose EHentai Files"
"Loose HGamesCG Files"
"Loose ImgBox Files"
"Loose LoveFap Files"
"Loose Pixeldrain Files"
"Loose Pixeldrain Files"
"Loose PostImg Files"
"Loose Saint Files"
"Loose ShareX Files"
"Loose ShareX Files"
"Loose XBunkr Files"
```