### PR TITLE
Deduplicate calculation of threads number

### DIFF
--- a/cyberdrop_dl/downloader/downloader_utils.py
+++ b/cyberdrop_dl/downloader/downloader_utils.py
@@ -1,3 +1,4 @@
+import multiprocessing
 import shutil
 from base64 import b64encode
 from enum import IntEnum
@@ -39,6 +40,13 @@ async def check_free_space(required_space_gb: int, download_directory: Path) -> 
     free_space = shutil.disk_usage(download_directory.parent).free
     free_space_gb = free_space / 1024 ** 3
     return free_space_gb >= required_space_gb
+
+
+async def get_threads_number(args: dict, domain: str) -> int:
+    threads = args["Runtime"]["simultaneous_downloads_per_domain"] or multiprocessing.cpu_count()
+    if any(s in domain for s in ('anonfiles', 'bunkr', 'pixeldrain')):
+        return min(threads, 2)
+    return threads
 
 
 async def is_4xx_client_error(status_code: int) -> bool:

--- a/cyberdrop_dl/downloader/downloaders.py
+++ b/cyberdrop_dl/downloader/downloaders.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import itertools
 import logging
-import multiprocessing
 from http import HTTPStatus
 from random import gauss
 
@@ -29,6 +28,7 @@ from .downloader_utils import (
     allowed_filetype,
     basic_auth,
     check_free_space,
+    get_threads_number,
     is_4xx_client_error,
     retry,
 )
@@ -337,8 +337,6 @@ class Downloader:
 async def download_cascade(args: dict, Cascade: CascadeItem, SQL_Helper: SQLHelper, client: Client,
                            scraper: ScrapeMapper) -> None:
     """Handler for cascades and the progress bars for it"""
-    user_threads = args["Runtime"]["simultaneous_downloads_per_domain"]
-
     progress_table = await get_cascade_table(args["Progress_Options"])
     total_files = await Cascade.get_total()
     files = Files(overall_file_progress.add_task("[green]Completed", total=total_files),
@@ -351,9 +349,7 @@ async def download_cascade(args: dict, Cascade: CascadeItem, SQL_Helper: SQLHelp
         tasks = []
 
         for domain, domain_obj in Cascade.domains.items():
-            threads = user_threads if user_threads != 0 else multiprocessing.cpu_count()
-            if 'bunkr' in domain or 'pixeldrain' in domain or 'anonfiles' in domain:
-                threads = 2 if (threads > 2) else threads
+            threads = await get_threads_number(args, domain)
             downloader = Downloader(args, client, SQL_Helper, scraper, threads, domain, domain_obj, files)
             tasks.append(downloader.start_domain(cascade_task))
         await asyncio.gather(*tasks)
@@ -370,8 +366,6 @@ async def download_cascade(args: dict, Cascade: CascadeItem, SQL_Helper: SQLHelp
 async def download_forums(args: dict, Forums: ForumItem, SQL_Helper: SQLHelper, client: Client,
                           scraper: ScrapeMapper) -> None:
     """Handler for forum threads and the progress bars for it"""
-    user_threads = args["Runtime"]["simultaneous_downloads_per_domain"]
-
     progress_table = await get_forum_table(args["Progress_Options"])
     total_files = await Forums.get_total()
     files = Files(overall_file_progress.add_task("[green]Completed", total=total_files),
@@ -385,9 +379,7 @@ async def download_forums(args: dict, Forums: ForumItem, SQL_Helper: SQLHelper, 
             tasks = []
 
             for domain, domain_obj in Cascade.domains.items():
-                threads = user_threads if user_threads != 0 else multiprocessing.cpu_count()
-                if 'bunkr' in domain or 'pixeldrain' in domain or 'anonfiles' in domain:
-                    threads = 2 if (threads > 2) else threads
+                threads = await get_threads_number(args, domain)
                 downloader = Downloader(args, client, SQL_Helper, scraper, threads, domain, domain_obj, files)
                 tasks.append(downloader.start_domain(cascade_task))
             await asyncio.gather(*tasks)


### PR DESCRIPTION
Should we move `args["Runtime"]["simultaneous_downloads_per_domain"] or multiprocessing.cpu_count()` to `get_threads_number` too?