### PR TITLE
Add missing headers argument in old downloaders

### DIFF
--- a/cyberdrop_dl/downloader/old_downloaders.py
+++ b/cyberdrop_dl/downloader/old_downloaders.py
@@ -288,7 +288,7 @@ class Old_Downloader:
         while True:
             if not expected_size:
                 expected_size = await self.download_session.get_filesize(media.url, str(media.referer),
-                                                                         current_throttle)
+                                                                         current_throttle, {})
 
             if not complete_file.exists() and not partial_file.exists():
                 break


### PR DESCRIPTION
This fixes `TypeError: DownloadSession.get_filesize() missing 1 required positional argument: 'headers'` which was changed in commit e082e6e630fdb599a73c08356e503e5b8f3796ba