### PR TITLE
Fix download of text files

### DIFF
--- a/cyberdrop_dl/base_functions/base_functions.py
+++ b/cyberdrop_dl/base_functions/base_functions.py
@@ -39,6 +39,10 @@ FILE_FORMATS = {
     },
     'Audio': {
         '.mp3', '.flac', '.wav', '.m4a',
+    },
+    'Text': {
+        '.htm', '.html', '.md', '.nfo',
+        '.txt',
     }
 }
 

--- a/cyberdrop_dl/client/client.py
+++ b/cyberdrop_dl/client/client.py
@@ -15,17 +15,16 @@ import certifi
 from aiolimiter import AsyncLimiter
 from bs4 import BeautifulSoup
 from multidict import CIMultiDictProxy
+from pathlib import Path
 from tqdm import tqdm
 from yarl import URL
 
-from ..base_functions.base_functions import logger
+from ..base_functions.base_functions import logger, FILE_FORMATS
 from ..base_functions.error_classes import DownloadFailure, InvalidContentTypeFailure
 from ..downloader.downloader_utils import CustomHTTPStatus
 from ..downloader.progress_definitions import ProgressMaster, adjust_title
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from rich.progress import TaskID
 
     from ..base_functions.data_classes import MediaItem
@@ -170,7 +169,9 @@ class DownloadSession:
                 raise DownloadFailure(code=CustomHTTPStatus.IM_A_TEAPOT, message="No content-type in response header")
             if resp.url in self.bunkr_maintenance:
                 raise DownloadFailure(code=HTTPStatus.SERVICE_UNAVAILABLE, message="Bunkr under maintenance")
-            if any(s in content_type.lower() for s in ('html', 'text')):
+
+            extname = Path(media.filename).suffix.lower()
+            if any(s in content_type.lower() for s in ('html', 'text')) and extname not in FILE_FORMATS['Text']:
                 logger.debug("Server for %s is experiencing issues, you are being ratelimited, or cookies have expired", media.url)
                 raise DownloadFailure(code=CustomHTTPStatus.IM_A_TEAPOT, message="Unexpectedly got text as response")
 


### PR DESCRIPTION
No longer throw errors if the content type is text and file name has a text file extension.