### PR TITLE
Fix local installation in editable mode

### DIFF
--- a/cyberdrop_dl/main.py
+++ b/cyberdrop_dl/main.py
@@ -28,7 +28,7 @@ from cyberdrop_dl.downloader.downloaders import DownloadDirector
 from cyberdrop_dl.downloader.old_downloaders import old_download_forums
 from cyberdrop_dl.scraper.Scraper import ScrapeMapper
 
-from . import __version__ as VERSION
+from .__init__ import __version__ as VERSION
 from .base_functions.base_functions import MAX_NAME_LENGTHS
 from .base_functions.data_classes import ForumItem, SkipData
 


### PR DESCRIPTION
This fixes local installation with `pip install -e .` which makes development easier. Without this it was erroring about not being able to do this import.