### PR TITLE
Suggestion: Adding parent directory to filename

### DIFF
--- a/cyberdrop_dl/base_functions/sorting_functions.py
+++ b/cyberdrop_dl/base_functions/sorting_functions.py
@@ -71,7 +71,8 @@ class Sorter:
 
     async def move_cd(self, file: Path, dest: Path) -> None:
         try:
-            dest_file = dest / file.name
+            new_name = "".join(x for x in file.parent.name  if x.isalnum()) + "_" + file.name
+            dest_file = dest / new_name
             file.rename(dest_file)
         except FileExistsError:
             if file.stat().st_size == dest_file.stat().st_size:


### PR DESCRIPTION
`Suggestion:`

Add the parent directory name to the sorted filename. The reason why is due to some of the folders containing the models set photo including set name an date. This information is lost when we move the raw file over to the sorted directory. 

Added an alphanumeric filter so that the parent directory removed any extra characters that might make the file name longer than needed. 

Another note, this avoid collisions and overwrites for files with similar filenames. 

@Jules-WinnfieldX please advise if needed changes. 