### PR TITLE
Fix concurrency limits

### DIFF
--- a/cyberdrop_dl/downloader/downloader_utils.py
+++ b/cyberdrop_dl/downloader/downloader_utils.py
@@ -51,7 +51,7 @@ async def check_free_space(required_space_gb: int, download_directory: Path) -> 
 
 def get_threads_number(args: Dict, domain: str) -> int:
     threads = args["Runtime"]["max_concurrent_downloads_per_domain"] or multiprocessing.cpu_count()
-    if any(s in domain for s in ('bunkr')):
+    if any(s in domain for s in ('bunkr',)):
         return min(threads, 1)
     if any(s in domain for s in ('anonfiles', 'pixeldrain', 'cyberfile')):
         return min(threads, 2)


### PR DESCRIPTION
Tuples are defined by the comma, so `('bunkr')` is treated as a string and any URL with a matching letter will be limited to 1 download.  

Fixes #615 