### PR TITLE
Use proxy in get_filesize()

### DIFF
--- a/cyberdrop_dl/client/client.py
+++ b/cyberdrop_dl/client/client.py
@@ -230,14 +230,14 @@ class DownloadSession:
 
         await self._download(media, current_throttle, proxy, headers, save_content, file)
 
-    async def get_filesize(self, url: URL, referer: str, current_throttle: float, headers: Dict) -> int:
+    async def get_filesize(self, url: URL, referer: str, current_throttle: float, headers: Dict, proxy: str) -> int:
         headers['Referer'] = referer
         headers['user-agent'] = self.client.user_agent
 
         assert url.host is not None
         await self._throttle(current_throttle, url.host)
         async with self.client_session.get(url, headers=headers, ssl=self.client.ssl_context,
-                                           raise_for_status=False) as resp:
+                                           raise_for_status=False, proxy=proxy) as resp:
             if resp.status > 206:
                 if "Server" in resp.headers:
                     if resp.headers["Server"] == "ddos-guard":

--- a/cyberdrop_dl/downloader/downloaders.py
+++ b/cyberdrop_dl/downloader/downloaders.py
@@ -328,7 +328,7 @@ class Downloader:
         while True:
             if not expected_size:
                 expected_size = await self.download_session.get_filesize(media.url, str(media.referer),
-                                                                         current_throttle, headers)
+                                                                         current_throttle, headers, self.CDL_Helper.proxy)
             if not complete_file.exists() and not partial_file.exists():
                 break
 

--- a/cyberdrop_dl/downloader/old_downloaders.py
+++ b/cyberdrop_dl/downloader/old_downloaders.py
@@ -288,7 +288,7 @@ class Old_Downloader:
         while True:
             if not expected_size:
                 expected_size = await self.download_session.get_filesize(media.url, str(media.referer),
-                                                                         current_throttle, headers)
+                                                                         current_throttle, headers, self.proxy)
 
             if not complete_file.exists() and not partial_file.exists():
                 break


### PR DESCRIPTION
Allows bypassing DDoS Guard for bunkrr and others using external proxies. Successfully tested with a bunkrr link from a low-reputation IP address that ran into the DDoS Guard error when downloading directly (without proxy).