### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11
+
+WORKDIR /cyberdrop-dl
+
+RUN pip3 install --upgrade cyberdrop-dl
+
+RUN ln -s /cyberdrop-dl/AppData/Configs /cyberdrop-dl/Configs && \
+    ln -s /cyberdrop-dl/AppData/Cache /cyberdrop-dl/Cache
+
+ENV APPDATA_FOLDER='/cyberdrop-dl'
+
+CMD /usr/local/bin/python3 /usr/local/bin/cyberdrop-dl --appdata-folder ${APPDATA_FOLDER} --download-all-configs --no-ui


### PR DESCRIPTION
Hello! Thanks for this project - I really appreciate all of the work you've put into this!

I'd been running v4 for a few months, and things worked great. When v5 came out, my setup unexpectedly broke - I think I tracked it down to my Python version. I'm running Python 3.9 on Unraid, installed via the NerdTools plugin, and CyberDrop-DL v5 requires Python 3.11. NerdTools unfortunately doesn't support Python 3.11, and it's unclear if it ever will. In fact, I couldn't find any way to install Python 3.11 on Unraid, so I set out to run CyberDrop-DL via Docker instead.

I think I can call this a success! It's not perfect, but it's working for me. I'm not new to running Docker containers, but I'm completely new to building Docker images. Here's the relevant snippet from my docker-compose.yaml file, which I'm using to build the image/container:

```
    cyberdrop-dl:
        container_name: cyberdrop-dl
        build:
            dockerfile: /mnt/user/appdata/cyberdrop-dl/Dockerfile
        volumes:
            - /mnt/user/appdata/cyberdrop-dl/AppData/Configs:/cyberdrop-dl/AppData/Configs
            - /mnt/user/appdata/cyberdrop-dl/AppData/Cache:/cyberdrop-dl/AppData/Cache
            - /mnt/user/downloaded_files:/mnt/user/downloaded_files
        networks:
            - containers
        restart: "no"
```

A few notes:

- This is running as root, which probably isn't the safest. I really tried to get this container running as non-root, but I kept running into permissions errors. This means that any files you download will also be owned by root, and you'll probably need to fix their permissions.
- It'd be nice to be able to specify the CLI arguments via environment variables, but I couldn't figure that out, either. For example, if someone doesn't want `--download-all-configs` or `--no-ui` (which are currently hardcoded in the Dockerfile).
- Once CyberDrop-DL is finished running through `URLs.txt`, the container continues running, but the app logs that it's finished and exits. It won't start downloading again until the container is restarted. As a workaround,I have a cron job that restarts it overnight.
- I ran into some weird path issues, where if I specified `--appdata-folder` as `/cyberdrop-dl/AppData`, it would try to write to the root of `cyberdrop-dl`. However, if I specified `--appdata-folder` as the root of `cyberdrop-dl`, it would create `/cyberdrop-dl/AppData` and try to run things from there. I eventually settled on creating a symlink between the two, since I wanted it to use my volume's data.
- I realize that it's now best practice to use a virtual environment for installing stuff via pip, but I didn't spend a ton of time trying to figure that out.
- In my default config's `settings.yaml` file, I'm setting `input_file` to `/cyberdrop-dl/Configs/Default/URLs.txt`.
- I'm also setting `download_folder` to `/mnt/user/downloaded_files/CyberDrop`.
- Lastly, I'm setting `log_folder` to `/cyberdrop-dl/AppData/Cache/logs`, so they're written to the Docker volume.

If someone knows how to do this better, I'd really appreciate help! That said, I hope this gets someone else up and running, particularly if they're in the same predicament as me. :)