### PR TITLE
Add dates to history

### DIFF
--- a/cyberdrop_dl/utils/database/table_definitions.py
+++ b/cyberdrop_dl/utils/database/table_definitions.py
@@ -6,6 +6,8 @@ create_history = """CREATE TABLE IF NOT EXISTS media (domain TEXT,
                                                download_filename TEXT,
                                                original_filename TEXT,
                                                completed INTEGER NOT NULL,
+                                               created_at TIMESTAMP,
+                                               completed_at TIMESTAMP,
                                                PRIMARY KEY (domain, url_path, original_filename)
                                                );"""
 


### PR DESCRIPTION
Not sure if this is something you're interested in, but I figured I'd toss it your way in case you were. I added this in my fork so that I could find the recently downloaded files without having to recrawl the filesystem every time.

---

This adds `created_at` and `completed_at` columns to the DB.

# Uses

This is useful for several possible future uses. For example:

## Finding files for cleanup

Bad files are sometimes downloaded during an outage. Such as when Bunker creates a new maintenance video before cyberdrop-dl knows the new path or Etag. If you know when the issue was occurring, this allows one to find which files might be bad and need to be redownloaded.

## Prioritizing recently added items

Items that have been incomplete for a long time will most likely never finish, so trying them first just burns through your rate limit. If the more recently added items are tried first they are more likely to succeed before the rate limit is hit.

# Details

| Column | Description
|:--------|:-------------
| `created_at` | When the item was added to the DB
| `completed_at` | When the item was marked completed

The columns are obviously unset for items that predate these additions.
